### PR TITLE
Fix StatsDisplay UI parity

### DIFF
--- a/packages/content-hub/src/components/screen-planner/ScreenPlannerApp.tsx
+++ b/packages/content-hub/src/components/screen-planner/ScreenPlannerApp.tsx
@@ -8,7 +8,7 @@ const ScreenPlannerApp: ComponentType = () => {
   return (
     <>
       <SettingsPanel config={screenConfig} />
-      <StatsDisplay results={screenConfig.calculatedResults} />
+      <StatsDisplay config={screenConfig} results={screenConfig.calculatedResults} />
       <ScreenVisualizer data={screenConfig.visualizationData} />
     </>
   )

--- a/packages/content-hub/src/components/screen-planner/StatsDisplay.tsx
+++ b/packages/content-hub/src/components/screen-planner/StatsDisplay.tsx
@@ -6,36 +6,75 @@ type ConfigState = ReturnType<typeof createScreenConfigState>
 type CalculatedResults = ConfigState['calculatedResults']
 
 interface StatsDisplayProps {
+  config: ConfigState
   results: CalculatedResults
 }
 
-const StatsDisplay: ComponentType<StatsDisplayProps> = ({ results }) => {
+const StatsDisplay: ComponentType<StatsDisplayProps> = ({ config, results }) => {
   const res = results.value
+  const { screen, distance, layout, curvature } = config
+  const { diagIn, ratio, screenWidth, screenHeight, inputMode } = screen
+  const { distCm } = distance
+  const { setupType } = layout
+  const { isCurved, curveRadius } = curvature
+
+  const sizeDisplay =
+    inputMode.value === 'diagonal'
+      ? `${diagIn.value}″ ${ratio.value}`
+      : `${screenWidth.value}×${screenHeight.value}mm`
   return (
     <section class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div class="bg-white rounded-lg shadow-sm border border-gray-600 p-4">
+      <div class="bg-white rounded-lg shadow-sm border p-4">
         <div class="text-center mb-2">
-          <span class="inline-block text-sm font-medium bg-gray-100 text-gray-600 px-3 py-1 rounded-full">
+          <span class="inline-block text-sm font-medium bg-gray-100 text-gray-600 px-3 py-1 rounded-full mb-4">
             Main Setup
           </span>
+          <div class="text-xs flex justify-center items-center">
+            <span>
+              <span class="text-gray-600 text-sm">
+                {setupType.value === 'triple' ? 'Triple' : 'Single'}
+              </span>
+            </span>
+            <span class="mx-2 text-gray-300">|</span>
+            <span>
+              <span class="text-gray-600 text-sm">{sizeDisplay}</span>
+            </span>
+            <span class="mx-2 text-gray-300">|</span>
+            <span>
+              <span class="text-gray-600 text-sm">
+                {isCurved.value ? `Curved (${curveRadius.value}R)` : 'Flat'}
+              </span>
+            </span>
+            <span class="mx-2 text-gray-300">|</span>
+            <span>
+              <span class="text-gray-400">Distance:</span>{' '}
+              <span class="text-gray-600 text-sm">{distCm.value}cm</span>
+            </span>
+          </div>
         </div>
-        <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-center">
-          <Card v={`${res.hFOVdeg.toFixed(0)}°`} l="H-FOV" tooltip="Horizontal field-of-view" />
-          <Card v={`${res.vFOVdeg.toFixed(0)}°`} l="V-FOV" tooltip="Vertical field-of-view" />
-          <Card
-            v={`${res.sideAngleDeg.toFixed(0)}°`}
-            l="Side Angle"
-            tooltip="Recommended monitor angle"
-          />
-          <Card
-            v={`${res.totalWidth.toFixed(0)} cm`}
-            l="Total Width"
-            tooltip="Overall monitor span"
-          />
+        <div class="border-t border-gray-200 my-2" />
+        <div class="text-center mt-2">
+          <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-center">
+            <Card v={`${res.hFOVdeg.toFixed(1)}°`} l="H-FOV" tooltip="Horizontal field-of-view" />
+            <Card v={`${res.vFOVdeg.toFixed(1)}°`} l="V-FOV" tooltip="Vertical field-of-view" />
+            <Card
+              v={`${res.sideAngleDeg.toFixed(1)}°`}
+              l="Side Angle"
+              tooltip="Recommended monitor angle"
+            />
+            <Card
+              v={`${res.totalWidth.toFixed(1)} cm`}
+              l="Total Width"
+              tooltip="Overall monitor span"
+            />
+          </div>
         </div>
       </div>
-      <div class="bg-white rounded-lg shadow-sm border border-blue-200 p-4 flex items-center justify-center text-blue-600 font-medium cursor-pointer hover:border-blue-500 transition-colors">
-        + Add Comparison
+      <div class="bg-white rounded-lg shadow-sm border border-blue-200 p-4 flex flex-col items-center justify-center cursor-pointer hover:border-blue-500 transition-colors">
+        <div class="text-xl font-semibold text-blue-600 py-4">Add a Comparison</div>
+        <div class="text-sm text-blue-500 mb-2 text-center">
+          Compare with standard triple 32&quot; flat setup
+        </div>
       </div>
     </section>
   )

--- a/packages/content-hub/src/layouts/BaseLayout.astro
+++ b/packages/content-hub/src/layouts/BaseLayout.astro
@@ -19,21 +19,22 @@ const {
 
 	<body class="min-h-full flex flex-col bg-gray-50 text-gray-900 antialiased">
 		<!-- Site Header -->
-		<header class="bg-gray-900 text-white">
-			<div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
-				<a href="/" class="text-lg font-semibold tracking-wide">SimRigBuild</a>
-
-				<nav class="space-x-6 text-sm">
-					<a href="/" class="hover:text-indigo-300 transition-colors">Home</a>
-					<a
-						href="/screen-planner"
-						class="hover:text-indigo-300 transition-colors"
-						>Screen Planner</a
-					>
-					<!-- Add further links as needed -->
-				</nav>
-			</div>
-		</header>
+<header class="bg-white border-b">
+        <div class="max-w-6xl mx-auto px-4 py-4 flex items-center">
+                <a
+                        href="https://simrigbuild.com"
+                        class="text-lg font-semibold text-blue-600 hover:text-blue-700 transition-colors"
+                >
+                        SimRigBuild.com
+                </a>
+                {title !== 'SimRigBuild' && (
+                        <>
+                                <span class="mx-2 text-gray-400">/</span>
+                                <h1 class="text-lg font-medium">{title}</h1>
+                        </>
+                )}
+        </div>
+</header>
 
 		<!-- Main Content -->
 		<main class="flex-1 p-6 max-w-5xl mx-auto space-y-6">

--- a/packages/content-hub/src/pages/screen-planner.astro
+++ b/packages/content-hub/src/pages/screen-planner.astro
@@ -5,12 +5,6 @@ import ScreenPlannerApp from '../components/screen-planner/ScreenPlannerApp.tsx'
 
 <BaseLayout title="Screen Planner">
   <div class="p-6 max-w-5xl mx-auto space-y-6">
-    <header class="flex items-center h-10 mb-2">
-      <a href="https://simrigbuild.com" class="text-xl font-semibold text-blue-600 hover:text-blue-700 transition-colors">SimRigBuild.com</a>
-      <span class="mx-2 text-gray-400">/</span>
-      <h1 class="text-xl font-medium">Screen Planner</h1>
-    </header>
-
     <ScreenPlannerApp client:load />
 
     <footer>


### PR DESCRIPTION
## Summary
- sync `StatsDisplay` in content hub with old React implementation
- pass screen config into `StatsDisplay`
- tweak header layout in `BaseLayout.astro` and remove duplicate heading in page

## Testing
- `pnpm test`
- `pnpm lint --silent` (with warnings)