### PR TITLE
Fix ESLint errors in content hub package

### DIFF
--- a/packages/content-hub/src/components/screen-planner/SettingsPanel.tsx
+++ b/packages/content-hub/src/components/screen-planner/SettingsPanel.tsx
@@ -6,6 +6,10 @@ import {
   createScreenConfigState,
   createScreenPlannerState,
   createCalculationState,
+  InputMode,
+  AspectRatio,
+  SetupType,
+  AngleMode,
 } from '@simrigbuild/screen-planner-core'
 
 type ConfigState = ReturnType<typeof createScreenConfigState>
@@ -36,9 +40,9 @@ const SettingsPanel: ComponentType<SettingsPanelProps> = ({ config, plannerStore
         {/* Screen Size */}
         <div class="bg-gray-50 rounded-lg p-3">
           <h3 class="text-sm font-medium text-gray-700 mb-2">Screen Size</h3>
-          <MultiToggle
+          <MultiToggle<InputMode>
             value={inputMode.value}
-            onChange={v => (inputMode.value = v as any)}
+            onChange={v => (inputMode.value = v as InputMode)}
             options={[
               { value: 'diagonal', label: 'Diagonal' },
               { value: 'manual', label: 'Width × Height' },
@@ -53,10 +57,10 @@ const SettingsPanel: ComponentType<SettingsPanelProps> = ({ config, plannerStore
                 value={diagonal.value}
                 onChange={v => (diagonal.value = v)}
               />
-              <MultiToggle
+              <MultiToggle<AspectRatio>
                 label="Aspect Ratio"
                 value={aspectRatio.value}
-                onChange={v => (aspectRatio.value = v as any)}
+                onChange={v => (aspectRatio.value = v as AspectRatio)}
                 options={[
                   { value: '16:9', label: '16:9' },
                   { value: '21:9', label: '21:9' },
@@ -106,9 +110,9 @@ const SettingsPanel: ComponentType<SettingsPanelProps> = ({ config, plannerStore
         {/* Screen Layout */}
         <div class="bg-gray-50 rounded-lg p-3">
           <h3 class="text-sm font-medium text-gray-700 mb-2">Screen Layout</h3>
-          <MultiToggle
+          <MultiToggle<SetupType>
             value={setupType.value}
-            onChange={v => (setupType.value = v as any)}
+            onChange={v => (setupType.value = v as SetupType)}
             options={[
               { value: 'single', label: 'Single' },
               { value: 'triple', label: 'Triple' },
@@ -116,10 +120,10 @@ const SettingsPanel: ComponentType<SettingsPanelProps> = ({ config, plannerStore
           />
           {setupType.value === 'triple' ? (
             <div class="mt-3 space-y-3">
-              <MultiToggle
+              <MultiToggle<AngleMode>
                 label="Side Screen Angle"
                 value={angleMode.value}
-                onChange={v => (angleMode.value = v as any)}
+                onChange={v => (angleMode.value = v as AngleMode)}
                 options={[
                   { value: 'auto', label: 'Auto' },
                   { value: 'manual', label: 'Manual' },

--- a/packages/content-hub/src/components/screen-planner/__tests__/ScreenPlannerApp.test.tsx
+++ b/packages/content-hub/src/components/screen-planner/__tests__/ScreenPlannerApp.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import ScreenPlannerApp from '../ScreenPlannerApp'
-import { h } from 'preact'
+import { h as _h } from 'preact'
 import renderToString from 'preact-render-to-string'
 
 describe('ScreenPlannerApp', () => {

--- a/packages/content-hub/src/components/screen-planner/__tests__/SettingsPanel.test.tsx
+++ b/packages/content-hub/src/components/screen-planner/__tests__/SettingsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { h } from 'preact'
+import { h as _h } from 'preact'
 import renderToString from 'preact-render-to-string'
 import SettingsPanel from '../SettingsPanel'
 import { screenPlanner } from '@simrigbuild/screen-planner-core'

--- a/packages/content-hub/src/components/screen-planner/__tests__/StatsDisplay.test.tsx
+++ b/packages/content-hub/src/components/screen-planner/__tests__/StatsDisplay.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { screenPlanner } from '@simrigbuild/screen-planner-core'
 import StatsDisplay from '../StatsDisplay'
-import { h } from 'preact'
+import { h as _h } from 'preact'
 import renderToString from 'preact-render-to-string'
 
 describe('StatsDisplay', () => {

--- a/packages/content-hub/src/components/ui/MultiToggle.tsx
+++ b/packages/content-hub/src/components/ui/MultiToggle.tsx
@@ -1,17 +1,17 @@
-import type { ComponentType, ComponentChildren } from 'preact'
+import type { ComponentChildren } from 'preact'
 
-export interface MultiToggleOption {
-  value: string
+export interface MultiToggleOption<T extends string = string> {
+  value: T
   label: ComponentChildren
 }
 
-interface MultiToggleProps {
+export interface MultiToggleProps<T extends string = string> {
   /** Currently selected value */
-  value: string
+  value: T
   /** Toggle options */
-  options: MultiToggleOption[]
+  options: MultiToggleOption<T>[]
   /** Fired when a new option is selected */
-  onChange: (value: string) => void
+  onChange: (value: T) => void
   /** Optional label displayed above the toggle */
   label?: string
 }
@@ -19,23 +19,25 @@ interface MultiToggleProps {
 /**
  * Multi-option toggle switch, rewritten from React to Preact/TS.
  */
-const MultiToggle: ComponentType<MultiToggleProps> = ({ value, options, onChange, label }) => (
-  <div>
-    {label && <div class="text-xs text-gray-600 mb-0.5">{label}</div>}
-    <div class="flex gap-1 p-1 bg-gray-100 rounded-lg">
-      {options.map(opt => (
-        <button
-          key={opt.value}
-          class={`flex-1 px-3 py-1.5 text-sm rounded-md transition-colors ${
-            value === opt.value ? 'bg-white text-gray-900 font-medium shadow-sm' : 'text-gray-600'
-          }`}
-          onClick={() => onChange(opt.value)}
-        >
-          {opt.label}
-        </button>
-      ))}
+function MultiToggle<T extends string>({ value, options, onChange, label }: MultiToggleProps<T>) {
+  return (
+    <div>
+      {label && <div class="text-xs text-gray-600 mb-0.5">{label}</div>}
+      <div class="flex gap-1 p-1 bg-gray-100 rounded-lg">
+        {options.map(opt => (
+          <button
+            key={opt.value}
+            class={`flex-1 px-3 py-1.5 text-sm rounded-md transition-colors ${
+              value === opt.value ? 'bg-white text-gray-900 font-medium shadow-sm' : 'text-gray-600'
+            }`}
+            onClick={() => onChange(opt.value)}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default MultiToggle


### PR DESCRIPTION
## Summary
- add generic support in `MultiToggle`
- type SettingsPanel MultiToggle handlers with explicit unions
- mark JSX `h` imports as intentionally unused in tests

## Testing
- `pnpm --filter @simrigbuild/content-hub lint`
- `pnpm --filter @simrigbuild/content-hub test`
